### PR TITLE
Fix Exhibition Pre-flight and Add hierarchical file counts and non-empty collection filtering

### DIFF
--- a/smartgallery.py
+++ b/smartgallery.py
@@ -2736,7 +2736,7 @@ def check_exhibition_requirements():
     """
     Strict Pre-Flight Check for Exhibition Mode.
     Ensures that the Main gallery has been run before, the database exists, 
-    and at least one public collection is configured.
+    and at least one public or user-shared collection is configured.
     Exits the application if requirements are not met to prevent ghost databases.
     """
     if not IS_EXHIBITION_MODE:
@@ -2771,19 +2771,23 @@ def check_exhibition_requirements():
                 print(f"   {Colors.YELLOW}python smartgallery.py{Colors.RESET}\n")
                 sys.exit(1)
 
-            # Check if there is at least one PUBLIC user album
-            public_colls = conn.execute("SELECT COUNT(*) FROM collections WHERE type='user_album' AND is_public=1").fetchone()[0]
-            
-            if public_colls == 0:
-                print(f"\n{Colors.RED}{Colors.BOLD}❌ CRITICAL ERROR: No Exhibition Ready Collections Found{Colors.RESET}")
-                print(f"{Colors.RED}Exhibition Mode is a showcase. It only displays collections marked as 'Exhibition Ready'.{Colors.RESET}")
-                print(f"{Colors.RED}Currently, your database has 0 Exhibition Ready collections, so the Exhibition would be completely empty.{Colors.RESET}")
+            # Check if at least one user album is public or shared with a user.
+            accessible_colls = conn.execute("""
+                SELECT COUNT(*)
+                FROM collections
+                WHERE type = 'user_album'
+                  AND (is_public = 1 OR TRIM(COALESCE(shared_users, '')) != '')
+            """).fetchone()[0]
+
+            if accessible_colls == 0:
+                print(f"\n{Colors.RED}{Colors.BOLD}❌ CRITICAL ERROR: No Exhibition Collections Found{Colors.RESET}")
+                print(f"{Colors.RED}Exhibition Mode displays collections that are public or shared with at least one user.{Colors.RESET}")
+                print(f"{Colors.RED}Currently, your database has no accessible Exhibition collections, so the Exhibition would be completely empty.{Colors.RESET}")
                 print(f"\n{Colors.CYAN}{Colors.BOLD}💡 HOW TO FIX IT:{Colors.RESET}")
                 print(f"1. Start the standard gallery: {Colors.YELLOW}python smartgallery.py{Colors.RESET}")
                 print(f"2. Log in, select some files, and click the 📚️ Add/Remove from collection button.")
-                print(f"3. Create a new Collection and answer 'Yes' when asked if it should be set as Exhibition Ready.")
-                print(f"   (Or edit an existing one from the sidebar menu: ⋮ -> 👁️ Set as Exhibition Ready).")
-                print(f"4. Once you have at least one public collection, restart with --exhibition.\n")
+                print(f"3. Mark a collection as Exhibition Ready or share it with at least one user.")
+                print(f"4. Restart with --exhibition.\n")
                 sys.exit(1)
                 
     except sqlite3.DatabaseError as e:

--- a/smartgallery.py
+++ b/smartgallery.py
@@ -6268,51 +6268,130 @@ def stream_video(file_id):
 
 # --- COLLECTIONS / CATEGORIES API ---
 
+def get_descendant_file_counts(conn, countable_collection_ids):
+    """Count unique files in descendant collections, excluding direct membership."""
+    if not countable_collection_ids:
+        return {}
+
+    placeholders = ','.join('?' for _ in countable_collection_ids)
+    rows = conn.execute(f"""
+        WITH RECURSIVE counted_descendants(id) AS (
+            SELECT DISTINCT collection_id
+            FROM collection_files
+            WHERE collection_id IN ({placeholders})
+        ), ancestry(ancestor_id, descendant_id) AS (
+            SELECT c.parent_id, c.id
+            FROM collections c
+            JOIN counted_descendants d ON d.id = c.id
+            WHERE c.parent_id IS NOT NULL
+            UNION
+            SELECT c.parent_id, a.descendant_id
+            FROM ancestry a
+            JOIN collections c ON c.id = a.ancestor_id
+            WHERE c.parent_id IS NOT NULL
+        )
+        SELECT a.ancestor_id, COUNT(DISTINCT cf.file_id) AS descendant_file_count
+        FROM ancestry a
+        JOIN collection_files cf ON cf.collection_id = a.descendant_id
+        WHERE a.ancestor_id != a.descendant_id
+        GROUP BY a.ancestor_id
+    """, countable_collection_ids).fetchall()
+    return {row['ancestor_id']: row['descendant_file_count'] for row in rows}
+
 
 @app.route('/galleryout/api/collections', methods=['GET'])
 def get_collections():
     user_id = str(session.get('user_id', '')).strip()
     user_role = session.get('role', 'GUEST')
     with get_db_connection() as conn:
-        # Fetch collections and force field types
-        rows = conn.execute("SELECT * FROM collections ORDER BY name").fetchall()
-        
-        filtered = []
-        for r in rows:
-            c = dict(r)
-            
-            # Logic for Exhibition Mode
-            if IS_EXHIBITION_MODE and user_role not in ['ADMIN', 'MANAGER', 'STAFF']:
-                if c['type'] == 'system_flag': continue
-                
-                # Check Public flag
+        rows = conn.execute("""
+            SELECT c.*,
+                   (SELECT COUNT(*) FROM collection_files cf WHERE cf.collection_id = c.id) AS file_count
+            FROM collections c
+            ORDER BY c.name
+        """).fetchall()
+
+        all_cols = [dict(r) for r in rows]
+        flags = [c for c in all_cols if c['type'] == 'system_flag']
+        albums = [c for c in all_cols if c['type'] == 'user_album']
+        for flag in flags:
+            flag.pop('file_count', None)
+
+        filtered_albums = []
+
+        if IS_EXHIBITION_MODE and user_role not in ['ADMIN', 'MANAGER', 'STAFF']:
+            explicit_access_ids = set()
+            album_dict = {c['id']: c for c in albums}
+
+            # Step 1: Identify explicitly accessible collections
+            for c in albums:
                 is_public = int(c.get('is_public', 0)) == 1
-                
-                # Robust Shared Users extraction
                 shared_raw = str(c.get('shared_users', '')).split(',')
-                # Remove spaces, ensure they are strings
                 shared_list = [str(uid).strip() for uid in shared_raw if uid.strip()]
-                
-                #DEBUG: Log what we are comparing
-                #print(f"DEBUG: Comparing UserID '{user_id}' against shared_list {shared_list}", c['name'])
-                
-                if not is_public and str(user_id) not in shared_list:
-                    continue
-                if not is_public and str(user_id) in shared_list:
-                    c['is_shared_access'] = True
-            
-            if IS_EXHIBITION_MODE and user_role in ['ADMIN', 'MANAGER', 'STAFF']:
-                # Robust Shared Users extraction
+
+                if is_public or str(user_id) in shared_list:
+                    explicit_access_ids.add(c['id'])
+                    if str(user_id) in shared_list:
+                        c['is_shared_access'] = True
+
+            # Step 2: Traverse upwards to unlock ancestor paths for the tree
+            required_ancestors = set()
+            for cid in explicit_access_ids:
+                curr = album_dict.get(cid)
+                while curr and curr.get('parent_id'):
+                    pid = curr['parent_id']
+                    required_ancestors.add(pid)
+                    curr = album_dict.get(pid)
+
+            # Step 3: Build final list with locked/unlocked flags
+            for c in albums:
+                if c['id'] in explicit_access_ids:
+                    c['restricted_access'] = False
+                    filtered_albums.append(c)
+                elif c['id'] in required_ancestors:
+                    c['restricted_access'] = True
+                    filtered_albums.append(c)
+
+        elif IS_EXHIBITION_MODE and user_role in ['ADMIN', 'MANAGER', 'STAFF']:
+            for c in albums:
                 shared_raw = str(c.get('shared_users', '')).split(',')
-                # Remove spaces, ensure they are strings
-                shared_list =[str(uid).strip() for uid in shared_raw if uid.strip()]
+                shared_list = [str(uid).strip() for uid in shared_raw if uid.strip()]
                 if shared_list:
                     c['is_shared_access'] = True
-                
-            filtered.append(c)
+                c['restricted_access'] = False
+            filtered_albums = albums
+
+        else:
+            for c in albums:
+                c['restricted_access'] = False
+            filtered_albums = albums
+
+        if IS_EXHIBITION_MODE:
+            count_album_ids = [
+                c['id'] for c in filtered_albums
+                if not c.get('restricted_access') and (c.get('is_public') or c.get('is_shared_access'))
+            ]
+        else:
+            count_album_ids = [c['id'] for c in filtered_albums]
+
+        all_count = 0
+        if count_album_ids:
+            placeholders = ','.join('?' for _ in count_album_ids)
+            all_count = conn.execute(
+                f"SELECT COUNT(DISTINCT file_id) FROM collection_files WHERE collection_id IN ({placeholders})",
+                count_album_ids
+            ).fetchone()[0]
+
+        descendant_counts = get_descendant_file_counts(conn, count_album_ids)
+        for c in filtered_albums:
+            c['descendant_file_count'] = descendant_counts.get(c['id'], 0)
+            if c.get('restricted_access'):
+                c['file_count'] = None
+
         return jsonify({
-            'flags': [c for c in filtered if c['type'] == 'system_flag'],
-            'albums': [c for c in filtered if c['type'] == 'user_album']
+            'flags': flags,
+            'albums': filtered_albums,
+            'all_count': all_count
         })
 
 @app.route('/galleryout/api/sidebar_state')
@@ -6321,14 +6400,39 @@ def get_sidebar_state():
     folders = get_dynamic_folder_config(force_refresh=True)
     with get_db_connection() as conn:
         flags = conn.execute("SELECT * FROM collections WHERE type='system_flag' ORDER BY id").fetchall()
-        albums = conn.execute("SELECT * FROM collections WHERE type='user_album' ORDER BY name").fetchall()
+        if IS_EXHIBITION_MODE:
+            albums = conn.execute("SELECT * FROM collections WHERE type='user_album' ORDER BY name").fetchall()
+            all_count = None
+        else:
+            albums = conn.execute("""
+                SELECT c.*,
+                       (SELECT COUNT(*) FROM collection_files cf WHERE cf.collection_id = c.id) AS file_count
+                FROM collections c
+                WHERE c.type='user_album'
+                ORDER BY c.name
+            """).fetchall()
+            all_count = conn.execute("""
+                SELECT COUNT(DISTINCT cf.file_id)
+                FROM collection_files cf
+                JOIN collections c ON c.id = cf.collection_id
+                WHERE c.type='user_album'
+            """).fetchone()[0]
+        album_dicts = [dict(r) for r in albums]
+        if not IS_EXHIBITION_MODE:
+            descendant_counts = get_descendant_file_counts(conn, [album['id'] for album in album_dicts])
+            for album in album_dicts:
+                album['descendant_file_count'] = descendant_counts.get(album['id'], 0)
+
+    collections = {
+        'flags': [dict(r) for r in flags],
+        'albums': album_dicts
+    }
+    if all_count is not None:
+        collections['all_count'] = all_count
     
     return jsonify({
         'folders': folders,
-        'collections': {
-            'flags': [dict(r) for r in flags],
-            'albums': [dict(r) for r in albums]
-        }
+        'collections': collections
     })
 
 @app.route('/galleryout/api/collections/rename', methods=['POST'])

--- a/templates/collections.html
+++ b/templates/collections.html
@@ -43,8 +43,10 @@
 
 let colSortState = { key: 'name', dir: 'asc' }; 
 let colSearchTerm = '';
-let collectionsData = { flags: [], albums: [], tree: {} };
+let colNonEmptyOnly = localStorage.getItem('galleryColNonEmptyOnly') === 'true';
+let collectionsData = { flags: [], albums: [], tree: {}, all_count: 0 };
 let colExpandedState = new Set(JSON.parse(localStorage.getItem('galleryColExpandedState') || '[]'));
+let collectionsRequestId = 0;
 
 function buildCollectionTreeData(albums) {
     let tree = { '_root_': [] };
@@ -74,15 +76,45 @@ function sortCollections(albumArray) {
     });
 }
 
+function getNonEmptyCollectionIds(albums) {
+    if (!colNonEmptyOnly) return null;
+
+    const albumMap = new Map(albums.map(album => [album.id, album]));
+    const visibleIds = new Set();
+    albums.filter(album => Number(album.file_count) > 0).forEach(album => {
+        let current = album;
+        while (current && !visibleIds.has(current.id)) {
+            visibleIds.add(current.id);
+            current = current.parent_id ? albumMap.get(current.parent_id) : null;
+        }
+    });
+    return visibleIds;
+}
+
+function expandNonEmptyCollectionPaths() {
+    const visibleIds = getNonEmptyCollectionIds(collectionsData.albums);
+    if (!visibleIds) return;
+
+    collectionsData.albums.forEach(album => {
+        const hasVisibleChild = (collectionsData.tree[album.id] || []).some(child => visibleIds.has(child.id));
+        if (visibleIds.has(album.id) && hasVisibleChild) colExpandedState.add(album.id);
+    });
+    localStorage.setItem('galleryColExpandedState', JSON.stringify([...colExpandedState]));
+}
+
 function loadCollections() {
-    fetch('/galleryout/api/collections')
+    const requestId = ++collectionsRequestId;
+    return fetch('/galleryout/api/collections')
     .then(r => r.json())
     .then(data => {
+        if (requestId !== collectionsRequestId) return;
+
         let parsedTree = buildCollectionTreeData(data.albums);
-        collectionsData = { flags: data.flags, albums: data.albums, tree: parsedTree.tree, map: parsedTree.albumMap };
+        collectionsData = { flags: data.flags, albums: data.albums, tree: parsedTree.tree, map: parsedTree.albumMap, all_count: data.all_count || 0 };
         
         const searchInp = document.getElementById('col-search-input');
         const sortBtn = document.getElementById('col-sort-toggle');
+        const nonEmptyBtn = document.getElementById('col-nonempty-toggle');
         
         if (searchInp && !searchInp.dataset.listening) {
             searchInp.dataset.listening = "true";
@@ -103,6 +135,26 @@ function loadCollections() {
             });
         }
 
+        if (nonEmptyBtn) {
+            nonEmptyBtn.classList.toggle('filter-active', colNonEmptyOnly);
+            nonEmptyBtn.setAttribute('aria-pressed', String(colNonEmptyOnly));
+            nonEmptyBtn.title = colNonEmptyOnly ? 'Show all collections' : 'Show only non-empty collections';
+            nonEmptyBtn.setAttribute('aria-label', nonEmptyBtn.title);
+            if (!nonEmptyBtn.dataset.listening) {
+                nonEmptyBtn.dataset.listening = "true";
+                nonEmptyBtn.addEventListener('click', () => {
+                    colNonEmptyOnly = !colNonEmptyOnly;
+                    localStorage.setItem('galleryColNonEmptyOnly', String(colNonEmptyOnly));
+                    if (colNonEmptyOnly) expandNonEmptyCollectionPaths();
+                    nonEmptyBtn.classList.toggle('filter-active', colNonEmptyOnly);
+                    nonEmptyBtn.setAttribute('aria-pressed', String(colNonEmptyOnly));
+                    nonEmptyBtn.title = colNonEmptyOnly ? 'Show all collections' : 'Show only non-empty collections';
+                    nonEmptyBtn.setAttribute('aria-label', nonEmptyBtn.title);
+                    renderSidebarCollections();
+                });
+            }
+        }
+
         renderSidebarCollections();
         
         const tagOverlay = document.getElementById('tagging-overlay');
@@ -116,18 +168,21 @@ function loadCollections() {
 // Global Sidebar Utilities
 async function syncSidebarState() {
     if (document.body.classList.contains('modal-open') || document.querySelector('.folder-dropdown.show')) return;
+    const requestId = ++collectionsRequestId;
     try {
         const res = await fetch('/galleryout/api/sidebar_state');
         const data = await res.json();
+        if (requestId !== collectionsRequestId) return;
+
         const folderHash = Object.keys(data.folders).length + Object.keys(data.folders).join('');
         const currentFolderHash = Object.keys(foldersData).length + Object.keys(foldersData).join('');
-        const collHash = data.collections.albums.map(a => a.id + a.name).join('');
-        const currentCollHash = collectionsData.albums.map(a => a.id + a.name).join('');
+        const collHash = data.collections.albums.map(a => `${a.id}:${a.name}:${a.file_count}:${a.descendant_file_count}`).join('|') + `|all:${data.collections.all_count}`;
+        const currentCollHash = collectionsData.albums.map(a => `${a.id}:${a.name}:${a.file_count}:${a.descendant_file_count}`).join('|') + `|all:${collectionsData.all_count}`;
         
         if (folderHash !== currentFolderHash || collHash !== currentCollHash) {
             foldersData = data.folders;
             let parsedTree = buildCollectionTreeData(data.collections.albums);
-            collectionsData = { flags: data.collections.flags, albums: data.collections.albums, tree: parsedTree.tree, map: parsedTree.albumMap };
+            collectionsData = { flags: data.collections.flags, albums: data.collections.albums, tree: parsedTree.tree, map: parsedTree.albumMap, all_count: data.collections.all_count || 0 };
             
             if(typeof renderAllTrees === 'function') renderAllTrees();
             renderSidebarCollections();
@@ -163,17 +218,24 @@ function restoreSidebarTab() {
     } else switchSidebarTab('folders');
 }
 
-function renderSidebarTreeHTML(parentId = '_root_', isSearching = false) {
+function renderSidebarTreeHTML(parentId = '_root_', isSearching = false, visibleIds = null) {
     let children = collectionsData.tree[parentId] || [];
     if (isSearching) {
         if (parentId === '_root_') children = collectionsData.albums.filter(c => c.name.toLowerCase().includes(colSearchTerm));
         else return ''; 
     }
+    if (visibleIds) {
+        children = isSearching
+            ? children.filter(c => Number(c.file_count) > 0)
+            : children.filter(c => visibleIds.has(c.id));
+    }
     let sortedChildren = sortCollections([...children]);
     let html = '';
 
     sortedChildren.forEach(c => {
-        let hasChildren = !isSearching && collectionsData.tree[c.id] && collectionsData.tree[c.id].length > 0;
+        let childCollections = collectionsData.tree[c.id] || [];
+        if (visibleIds) childCollections = childCollections.filter(child => visibleIds.has(child.id));
+        let hasChildren = !isSearching && childCollections.length > 0;
         let isExpanded = colExpandedState.has(c.id) || isSearching;
         let isCollapsedClass = !isExpanded && hasChildren ? 'collapsed' : '';
         
@@ -194,6 +256,8 @@ function renderSidebarTreeHTML(parentId = '_root_', isSearching = false) {
                 <a href="/galleryout/collection/${c.id}" class="folder-link navigation-link" style="display:flex; align-items:center; flex-grow:1;">
                     <span class="col-icon">📚</span>
                     <span class="col-name" title="${c.name}">${escapeHTML(c.name)}</span>
+                    ${Number(c.file_count) > 0 ? `<span class="collection-count" title="${c.file_count} directly tagged files">${c.file_count}</span>` : ''}
+                    ${hasChildren && !isExpanded && Number(c.descendant_file_count) > 0 ? `<span class="collection-count collection-count-descendant" title="${c.descendant_file_count} unique files in sub-collections">+${c.descendant_file_count}</span>` : ''}
                     ${publicIcon}
                 </a>
                 <div class="folder-menu-container">
@@ -211,7 +275,7 @@ function renderSidebarTreeHTML(parentId = '_root_', isSearching = false) {
                     </div>
                 </div>
             </div>
-            ${hasChildren ? `<ul style="list-style:none;">${renderSidebarTreeHTML(c.id, false)}</ul>` : ''}
+            ${hasChildren ? `<ul style="list-style:none;">${renderSidebarTreeHTML(c.id, false, visibleIds)}</ul>` : ''}
         </li>`;
     });
     return html;
@@ -232,14 +296,16 @@ function renderSidebarCollections() {
     const usrContainer = document.getElementById('user-collections-list');
     if (usrContainer) {
         const isAllActive = (typeof currentFolderInfo !== 'undefined' && currentFolderInfo.collection_id === 'all');
+        const visibleIds = getNonEmptyCollectionIds(collectionsData.albums);
         let allHeaderHtml = `
             <div style="padding-left:0;">
                 <a href="/galleryout/collection/all" class="col-item folder-item navigation-link ${isAllActive ? 'active' : ''}" style="margin-bottom: 8px; border-bottom: 1px solid var(--glass-border); padding-bottom: 10px;">
                     <span class="col-icon">🌈</span><span class="col-name" style="font-weight: bold;">All Collections</span>
+                    ${Number(collectionsData.all_count) > 0 ? `<span class="collection-count" title="${collectionsData.all_count} unique files">${collectionsData.all_count}</span>` : ''}
                 </a>
             </div>
             <ul class="folder-tree col-tree" id="main-col-tree" style="list-style:none; padding:0; margin:0;">
-                ${renderSidebarTreeHTML('_root_', colSearchTerm !== '')}
+                ${renderSidebarTreeHTML('_root_', colSearchTerm !== '', visibleIds)}
             </ul>`;
         usrContainer.innerHTML = allHeaderHtml;
     }
@@ -257,6 +323,9 @@ document.addEventListener('click', (e) => {
             if (isCollapsed) colExpandedState.delete(id);
             else colExpandedState.add(id);
             localStorage.setItem('galleryColExpandedState', JSON.stringify([...colExpandedState]));
+            renderSidebarCollections();
+            const tagOverlay = document.getElementById('tagging-overlay');
+            if (tagOverlay && tagOverlay.classList.contains('visible') && tmState.mode === 'collection') renderTagManagerList();
         }
     }
 }, true);
@@ -410,6 +479,8 @@ function renderTagManagerTreeHTML(parentId = '_root_', isSearching = false) {
                     <span class="tag-col-name" style="white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width: 150px; display:inline-block; vertical-align:middle; ${isOriginal && !pendingAction ? 'color: var(--success-color); font-weight: bold;' : ''}">
                         ${c.is_public ? '👁️ ' : ''}${c.name}
                     </span>
+                    ${Number(c.file_count) > 0 ? `<span class="collection-count" title="${c.file_count} directly tagged files">${c.file_count}</span>` : ''}
+                    ${hasChildren && !isExpanded && Number(c.descendant_file_count) > 0 ? `<span class="collection-count collection-count-descendant" title="${c.descendant_file_count} unique files in sub-collections">+${c.descendant_file_count}</span>` : ''}
                 </div>
                 <div style="display:flex; gap:5px; z-index:10;">
                     <button class="tag-action-btn btn-tag-add" ${addActive} onclick="setTagAction(${c.id}, 'add')" style="padding:4px 8px; font-size:0.8rem;">➕ Add</button>
@@ -541,6 +612,7 @@ async function applyTagManagerChanges() {
         } else {
             btn.disabled = false; btn.textContent = "💾 Apply Changes";
             closeTaggingModal();
+            loadCollections();
             if (typeof currentLightboxFile !== 'undefined' && !currentLightboxFile && typeof deselectAll === 'function') deselectAll();
         }
     } catch (e) {
@@ -564,6 +636,7 @@ async function untagCurrentCollection() {
         const data = await res.json();
         if (data.status === 'success') {
             showNotification(`Removed ${targets.length} item(s).`, "success");
+            loadCollections();
             targets.forEach(fid => {
                 const item = document.querySelector(`.gallery-item[data-file-id="${fid}"]`);
                 if (item) {

--- a/templates/css/index.css
+++ b/templates/css/index.css
@@ -6597,6 +6597,12 @@ body.dam-mode-active .gallery-item:has(.status-color-strip) .workflow-badge {
     transform: translateY(-1px);
 }
 
+.sidebar-tool-btn.filter-active {
+    background: rgba(0, 123, 255, 0.2);
+    border-color: var(--primary-color);
+    color: #a8dcff;
+}
+
 /* Adjustments for Sort Buttons to be icons too */
 .sort-btn-mini {
     font-size: 0.7rem;
@@ -6701,6 +6707,27 @@ text-align: left;
 white-space: nowrap;
 overflow: hidden;
 text-overflow: ellipsis;
+}
+
+.collection-count {
+flex-shrink: 0;
+min-width: 1.5rem;
+padding: 1px 6px;
+border-radius: 999px;
+background: rgba(0, 123, 255, 0.18);
+border: 1px solid rgba(137, 207, 240, 0.25);
+color: #a8dcff;
+font-size: 0.72rem;
+font-weight: 600;
+font-variant-numeric: tabular-nums;
+line-height: 1.35;
+text-align: center;
+}
+
+.collection-count-descendant {
+background: rgba(255, 255, 255, 0.06);
+border-color: rgba(255, 255, 255, 0.18);
+color: var(--text-muted);
 }
 
 /* DAM Mode Visibility */
@@ -7398,4 +7425,3 @@ body.sidebar-minimized .sidebar-user-row {
 }
     50% { outline: 6px solid #007bff !important; outline-offset: 4px !important; box-shadow: 0 0 25px rgba(0, 123, 255, 0.8) !important; }
 }
-

--- a/templates/exhibition.html
+++ b/templates/exhibition.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>SmartGallery Exhibition Mode</title>
     <link rel="icon" type="image/png" href="{{ app_logo_b64 }}">
- 
+
     <style>
     :root {
         --bg-color: #0a0a0a;
@@ -116,12 +116,13 @@
         border-bottom: 1px solid var(--border-color); position: relative; 
         flex-shrink: 0; 
     }
+    .sidebar-search-wrap { position: relative; display: flex; flex: 1; min-width: 0; }
     .search-input {
-        flex-grow: 1; background: rgba(0,0,0,0.4); border: 1px solid var(--glass-border);
+        width: 100%; min-width: 0; background: rgba(0,0,0,0.4); border: 1px solid var(--glass-border);
         border-radius: 6px; color: white; padding: 0 32px 0 10px; height: 34px; font-size: 0.85rem; outline: none;
     }
     .search-clear-btn {
-        position: absolute; right: 90px; /* Adjusted closer to sort buttons */ top: 50%;
+        position: absolute; right: 6px; top: 50%;
         transform: translateY(-50%); background: none; border: none; color: var(--text-muted);
         cursor: pointer; padding: 4px 6px; font-size: 1.2rem; line-height: 1; display: none;
         transition: color 0.2s; z-index: 10;
@@ -136,6 +137,7 @@
         white-space: nowrap;
     }
     .tool-btn:hover { background: var(--surface-hover); border-color: var(--primary-color); }
+    .tool-btn.filter-active { background: rgba(0, 123, 255, 0.2); border-color: var(--primary-color); color: #a8dcff; }
 
     /* Nav List (Scrollable Area) */
     .nav-list { 
@@ -194,6 +196,27 @@
         overflow: hidden;
         text-overflow: ellipsis;
         display: block;
+    }
+
+    .collection-count {
+        flex-shrink: 0;
+        min-width: 1.5rem;
+        padding: 1px 6px;
+        border-radius: 999px;
+        background: rgba(0, 123, 255, 0.18);
+        border: 1px solid rgba(137, 207, 240, 0.25);
+        color: #a8dcff;
+        font-size: 0.72rem;
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+        line-height: 1.35;
+        text-align: center;
+    }
+
+    .collection-count-descendant {
+        background: rgba(255, 255, 255, 0.06);
+        border-color: rgba(255, 255, 255, 0.18);
+        color: var(--text-muted);
     }
 
     /* Dots button (Hidden by default) */
@@ -716,11 +739,6 @@
             min-width: 38px;
         }
 
-        /* Adjust search clear button position for narrower mobile sidebar */
-        .search-clear-btn {
-            right: 96px !important; 
-        }
-        
         #theater-overlay { flex-direction: column; height: 100dvh; }
         
         /* MOBILE LIGHTBOX: Full-width image with overlaid arrows */
@@ -1533,10 +1551,13 @@
             </div>
         </a>
         <div class="sidebar-toolbar">
-            <input type="text" id="category-search" class="search-input" placeholder="🔍 Search Collections...">
-            <button class="search-clear-btn" id="search-clear-btn" onclick="clearSearch()" title="Clear search">×</button>
+            <div class="sidebar-search-wrap">
+                <input type="text" id="category-search" class="search-input" placeholder="🔍 Search Collections...">
+                <button class="search-clear-btn" id="search-clear-btn" onclick="clearSearch()" title="Clear search">×</button>
+            </div>
             <button class="tool-btn" id="cat-sort-type" onclick="cycleCatSortType()" title="Toggle sort by name/date">A-Z</button>
             <button class="tool-btn" id="cat-sort-dir" onclick="toggleCatSortDir()" title="Toggle sort direction">↓</button>
+            <button class="tool-btn" id="cat-nonempty-toggle" onclick="toggleCatNonEmpty()" title="Show only non-empty collections" aria-label="Show only non-empty collections" aria-pressed="false">&gt;0</button>
         </div>
         
         <ul class="nav-list" id="collection-list"></ul>
@@ -2483,7 +2504,8 @@
     let theaterPollingInterval = null;
     let displayedCount = 0, focusedGridIndex = -1;
     const CHUNK_SIZE = {{ page_size_from_backend | default(100) }};
-    let allCollections = [], categorySearchTerm = '';
+    let allCollections = [], allCollectionsCount = 0, categorySearchTerm = '';
+    let catNonEmptyOnly = localStorage.getItem('sg_exh_cat_nonempty_only') === 'true';
 
     // Technical configuration from backend
     const ffmpegAvailable = {{ ffmpeg_available | tojson }};
@@ -2904,6 +2926,7 @@
                 renderCategoryList();
             });
         }
+        updateCatNonEmptyUI();
         
         // --- INFINITE SCROLL OBSERVER SETUP ---
         const grid = document.getElementById('gallery-grid');
@@ -2997,28 +3020,46 @@
 
     // Polls the server for changes in public collections without refreshing the page
     // --- ROBUST COLLECTION SYNC FOR EXHIBITION ---
+    let collectionSyncRequestId = 0;
+
     async function loadCollections(isPolling = false) {
+        const requestId = ++collectionSyncRequestId;
         try {
             const res = await fetch('/galleryout/api/collections');
             const data = await res.json();
-            const newPublicAlbums = data.albums.filter(a => a.is_public || a.is_shared_access);
+            if (requestId !== collectionSyncRequestId) return;
+
+            // Allow restricted ancestors to pass through to build the tree
+            const newPublicAlbums = data.albums.filter(a => a.is_public || a.is_shared_access || a.restricted_access);
+            const previousActiveCount = currentCollectionId === 'all'
+                ? allCollectionsCount
+                : allCollections.find(c => c.id == currentCollectionId)?.file_count;
+            const nextActiveCount = currentCollectionId === 'all'
+                ? data.all_count
+                : newPublicAlbums.find(c => c.id == currentCollectionId)?.file_count;
+            const activeCountChanged = isPolling && currentCollectionId !== null && previousActiveCount !== nextActiveCount;
             
             // Generate a unique fingerprint of the public albums list
-            const newHash = newPublicAlbums.map(c => `${c.id}:${c.name}`).join('|');
-            const currentHash = allCollections.map(c => `${c.id}:${c.name}`).join('|');
+            const newHash = newPublicAlbums.map(c => `${c.id}:${c.name}:${c.file_count}:${c.descendant_file_count}`).join('|') + `|all:${data.all_count}`;
+            const currentHash = allCollections.map(c => `${c.id}:${c.name}:${c.file_count}:${c.descendant_file_count}`).join('|') + `|all:${allCollectionsCount}`;
 
             if (currentHash !== newHash) {
                 console.log("Sync: Public collections updated.");
                 allCollections = newPublicAlbums;
+                allCollectionsCount = data.all_count || 0;
                 renderCategoryList();
 
                 // Safety: if the current collection was deleted or set to private by Admin
                 if (currentCollectionId !== 'all' && currentCollectionId !== null) {
-                    const stillExists = allCollections.some(c => c.id == currentCollectionId);
+                    const stillExists = allCollections.some(c => c.id == currentCollectionId && !c.restricted_access);
                     if (!stillExists) {
-                        showNotification("This collection is no longer public.", "warning");
+                        showNotification("This collection is no longer accessible.", "warning");
                         loadGallery('all', 'All Collections');
+                    } else if (activeCountChanged) {
+                        loadGallery(currentCollectionId, document.getElementById('page-title').textContent);
                     }
+                } else if (currentCollectionId === 'all' && activeCountChanged) {
+                    loadGallery('all', 'All Collections');
                 }
             }
             
@@ -4158,13 +4199,13 @@
                 e.preventDefault(); 
                 submitRatingShortcut(parseInt(key)); 
                 closeExhMenu(); 
-                return; 
+                return;
             }
 
             e.stopPropagation(); // Block other keys while menu is open
             return;
         }
-        
+
         if (isTh && e.key === '/') { e.preventDefault(); openExhMenu(); return; }
 
         // --- GLOBAL ACTIONS (Rating) ---
@@ -4258,6 +4299,46 @@
         }
     }
 
+    let exhColExpandedState = new Set(JSON.parse(localStorage.getItem('exhColExpandedState') || '[]'));
+
+    function buildExhCollectionTreeData(albums) {
+        let tree = { '_root_': [] };
+        albums.forEach(a => tree[a.id] = []);
+        albums.forEach(a => {
+            let parent = a.parent_id || '_root_';
+            if (!tree[parent]) tree[parent] = [];
+            tree[parent].push(a);
+        });
+        return tree;
+    }
+
+    function getExhNonEmptyCollectionIds() {
+        if (!catNonEmptyOnly) return null;
+
+        const albumMap = new Map(allCollections.map(album => [album.id, album]));
+        const visibleIds = new Set();
+        allCollections.filter(album => Number(album.file_count) > 0).forEach(album => {
+            let current = album;
+            while (current && !visibleIds.has(current.id)) {
+                visibleIds.add(current.id);
+                current = current.parent_id ? albumMap.get(current.parent_id) : null;
+            }
+        });
+        return visibleIds;
+    }
+
+    function expandExhNonEmptyCollectionPaths() {
+        const visibleIds = getExhNonEmptyCollectionIds();
+        if (!visibleIds) return;
+
+        const tree = buildExhCollectionTreeData(allCollections);
+        allCollections.forEach(album => {
+            const hasVisibleChild = (tree[album.id] || []).some(child => visibleIds.has(child.id));
+            if (visibleIds.has(album.id) && hasVisibleChild) exhColExpandedState.add(album.id);
+        });
+        localStorage.setItem('exhColExpandedState', JSON.stringify([...exhColExpandedState]));
+    }
+
     function renderCategoryList() {
         const list = document.getElementById('collection-list'); 
         list.innerHTML = '';
@@ -4270,6 +4351,7 @@
         allLi.innerHTML = `
             <span style="flex-shrink:0;">🌈</span> 
             <span class="nav-text-wrapper" style="font-weight: bold;">All Collections</span>
+            ${Number(allCollectionsCount) > 0 ? `<span class="collection-count" title="${allCollectionsCount} unique files">${allCollectionsCount}</span>` : ''}
         `;
         allLi.onclick = () => { 
             activeSortCriteria = 'date';
@@ -4281,36 +4363,111 @@
         };
         list.appendChild(allLi);
 
-        // Standard filtering and sorting for other collections
-        let filtered = allCollections.filter(c => c.name.toLowerCase().includes(categorySearchTerm));
-        filtered.sort((a, b) => {
-            let result = (catSortType === 'date') ? (a.created_at - b.created_at) : a.name.localeCompare(b.name);
-            return (catSortDir === 'asc') ? result : -result;
-        });
-        
-        filtered.forEach(col => {
-            const li = document.createElement('li'); 
-            li.className = `nav-item ${currentCollectionId == col.id ? 'active' : ''}`;
-            li.dataset.id = col.id;
-            const safeName = escapeHtml(col.name).replace(/'/g, "\\'");
-            let iconStr = col.is_shared_access ? "👥" : "📚";
-            let textStyle = col.is_shared_access ? "color: var(--favorite-color);" : "";
-            li.innerHTML = `
-                <span style="flex-shrink:0; font-size:1.05rem;">${iconStr}</span> 
-                <span class="nav-text-wrapper" style="${textStyle}">${escapeHtml(col.name)}</span>
-                <button class="nav-expand-btn" title="Show full name" onclick="showFullName(event, '${safeName}')">•••</button>
-            `;
-            li.onclick = (e) => { 
-                if(e.target.closest('.nav-expand-btn')) return;
-                activeSortCriteria = 'date';
-                activeSortOrder = 'desc';
-                updateSortUI();
-                if (document.getElementById('sort-select')) document.getElementById('sort-select').value = 'date_desc';
-                loadGallery(col.id, col.name, li); 
-                if(window.innerWidth <= 1024) toggleMenu(); 
-            };
-            list.appendChild(li);
-        });
+        let tree = buildExhCollectionTreeData(allCollections);
+        let isSearching = categorySearchTerm !== '';
+        const visibleIds = getExhNonEmptyCollectionIds();
+
+        function renderNodes(parentId, parentElement, depth) {
+            let children = tree[parentId] || [];
+
+            if (isSearching && parentId === '_root_') {
+                children = allCollections.filter(c => c.name.toLowerCase().includes(categorySearchTerm));
+            } else if (isSearching) {
+                return;
+            }
+            if (visibleIds) {
+                children = isSearching
+                    ? children.filter(c => Number(c.file_count) > 0)
+                    : children.filter(c => visibleIds.has(c.id));
+            }
+
+            children.sort((a, b) => {
+                let result = (catSortType === 'date') ? (a.created_at - b.created_at) : a.name.localeCompare(b.name);
+                return (catSortDir === 'asc') ? result : -result;
+            });
+
+            children.forEach(col => {
+                let childCollections = tree[col.id] || [];
+                if (visibleIds) childCollections = childCollections.filter(child => visibleIds.has(child.id));
+                let hasChildren = !isSearching && childCollections.length > 0;
+                let isExpanded = exhColExpandedState.has(col.id) || isSearching;
+
+                const safeName = escapeHtml(col.name).replace(/'/g, "\\\'").replace(/"/g, "&quot;");
+
+                let iconStr = col.restricted_access ? "🔒" : (col.is_shared_access ? "👥" : "📚");
+                let textStyle = col.is_shared_access ? "color: var(--favorite-color);" : (col.restricted_access ? "color: var(--text-muted); opacity: 0.6;" : "");
+
+                let toggleIcon = '';
+                if (hasChildren && !isSearching) {
+                    toggleIcon = isExpanded ? '▾' : '▸';
+                }
+
+                const li = document.createElement('li');
+                li.style.listStyle = 'none';
+
+                const indent = depth * 20;
+
+                const itemDiv = document.createElement('div');
+                itemDiv.className = `nav-item ${currentCollectionId == col.id ? 'active' : ''}`;
+                itemDiv.dataset.id = col.id;
+
+                itemDiv.style.paddingLeft = `${12 + indent}px`;
+
+                itemDiv.innerHTML = `
+                    <span class="exh-col-toggle" style="cursor:pointer; font-weight:bold; width:15px; display:inline-block; flex-shrink:0; text-align:center; color:var(--text-muted); margin-right:5px;">${toggleIcon}</span>
+                    <span style="flex-shrink:0; font-size:1.05rem; margin-right:8px;">${iconStr}</span>
+                    <span class="nav-text-wrapper" style="${textStyle} ${col.restricted_access ? 'cursor:pointer;' : ''}">${escapeHtml(col.name)}</span>
+                    ${!col.restricted_access && Number(col.file_count) > 0 ? `<span class="collection-count" title="${col.file_count} directly tagged files">${col.file_count}</span>` : ''}
+                    ${hasChildren && !isExpanded && Number(col.descendant_file_count) > 0 ? `<span class="collection-count collection-count-descendant" title="${col.descendant_file_count} unique files in sub-collections">+${col.descendant_file_count}</span>` : ''}
+                    ${!col.restricted_access ? `<button class="nav-expand-btn" title="Show full name" onclick="showFullName(event, '${safeName}')">•••</button>` : ''}
+                `;
+
+                li.appendChild(itemDiv);
+
+                const toggleBtn = itemDiv.querySelector('.exh-col-toggle');
+                toggleBtn.onclick = (e) => {
+                    e.stopPropagation();
+                    if (hasChildren && !isSearching) {
+                        if (isExpanded) exhColExpandedState.delete(col.id);
+                        else exhColExpandedState.add(col.id);
+                        localStorage.setItem('exhColExpandedState', JSON.stringify([...exhColExpandedState]));
+                        renderCategoryList();
+                    }
+                };
+
+                itemDiv.onclick = (e) => {
+                    if(e.target.closest('.nav-expand-btn') || e.target.closest('.exh-col-toggle')) return;
+
+                    if (col.restricted_access) {
+                        if (hasChildren && !isSearching) toggleBtn.click();
+                        return;
+                    }
+
+                    activeSortCriteria = 'date';
+                    activeSortOrder = 'desc';
+                    updateSortUI();
+                    if (document.getElementById('sort-select')) document.getElementById('sort-select').value = 'date_desc';
+                    loadGallery(col.id, col.name, itemDiv);
+                    if(window.innerWidth <= 1024) toggleMenu();
+                };
+
+                parentElement.appendChild(li);
+
+                if (hasChildren && isExpanded && !isSearching) {
+                    const ul = document.createElement('ul');
+                    ul.style.padding = '0';
+                    ul.style.margin = '0';
+                    renderNodes(col.id, ul, depth + 1);
+                    li.appendChild(ul);
+                }
+            });
+        }
+
+        const ulWrapper = document.createElement('ul');
+        ulWrapper.style.padding = '0';
+        ulWrapper.style.margin = '0';
+        renderNodes('_root_', ulWrapper, 0);
+        list.appendChild(ulWrapper);
 
         requestAnimationFrame(() => { requestAnimationFrame(() => { checkSidebarOverflows(); }); });
     }
@@ -4425,6 +4582,23 @@
     function updateCatSortUI() { 
         document.getElementById('cat-sort-type').textContent = (catSortType === 'name') ? 'A-Z' : '📅'; 
         document.getElementById('cat-sort-dir').textContent = (catSortDir === 'asc') ? '↑' : '↓'; 
+    }
+
+    function toggleCatNonEmpty() {
+        catNonEmptyOnly = !catNonEmptyOnly;
+        localStorage.setItem('sg_exh_cat_nonempty_only', String(catNonEmptyOnly));
+        if (catNonEmptyOnly) expandExhNonEmptyCollectionPaths();
+        updateCatNonEmptyUI();
+        renderCategoryList();
+    }
+
+    function updateCatNonEmptyUI() {
+        const button = document.getElementById('cat-nonempty-toggle');
+        if (!button) return;
+        button.classList.toggle('filter-active', catNonEmptyOnly);
+        button.setAttribute('aria-pressed', String(catNonEmptyOnly));
+        button.title = catNonEmptyOnly ? 'Show all collections' : 'Show only non-empty collections';
+        button.setAttribute('aria-label', button.title);
     }
     
     async function changeNickname() { 
@@ -4560,7 +4734,10 @@
     /**
      * Refactored load logic to accept parameters directly
      */
+    let galleryRequestId = 0;
+
     async function loadGalleryInternal(collId, name, el = null) {
+        const requestId = ++galleryRequestId;
         currentCollectionId = collId; 
         document.getElementById('page-title').textContent = name;
         
@@ -4573,6 +4750,8 @@
                 headers: { 'Accept': 'application/json' } 
             });
             const data = await res.json(); 
+            if (requestId !== galleryRequestId || currentCollectionId != collId) return;
+
             currentFiles = data.files; 
             
             const countBadge = document.getElementById('file-count-total');

--- a/templates/index.html
+++ b/templates/index.html
@@ -332,6 +332,7 @@
                     <div class="sidebar-toolbar" style="border-bottom:none; padding: 5px 0 10px 0; display: flex; gap: 5px;">
                         <input type="search" class="search-input-compact" id="col-search-input" placeholder="🔍 Search collections..." style="flex-grow:1;">
                         <button class="sidebar-tool-btn sort-btn-mini" id="col-sort-toggle">A-Z</button>
+                        <button class="sidebar-tool-btn sort-btn-mini" id="col-nonempty-toggle" title="Show only non-empty collections" aria-label="Show only non-empty collections" aria-pressed="false">&gt;0</button>
                         <button class="sidebar-tool-btn" onclick="createNewCollection(false)" title="Create New Collection">➕</button>
                     </div>
                     <div id="user-collections-list" style="overflow-y: auto; flex: 1;">


### PR DESCRIPTION
Decided to issue a PR.

This is related some suggestions I commented on in after receiving the patch related exhibition view's missing tree display. Below is built off of the patch you sent in a zip. Codex was used.  Just realized after the PR, probably should add a little padding on the count badge in Admin. some styling house cleaning. 

- https://github.com/biagiomaf/smart-comfyui-gallery/issues/77
- https://github.com/biagiomaf/smart-comfyui-gallery/issues/75

**Summary**
Exhibition View Pre-Flight Fix and Adds file-count visibility and hierarchy-aware filtering to collection folders and sub-collections.

**Collection and Sub-Collection Changes**
- Displays files tagged directly to each collection.
- Hides count badges when the direct count is zero.
- Displays +N unique descendant files when a parent collection is collapsed.
- Counts files assigned to multiple descendant collections only once.
- Adds a persisted >0 filter to show non-empty collections.
- Retains parent folders required to reach non-empty descendants.
- Automatically expands retained paths when enabling the filter while still allowing them to be collapsed.
- Adds counts and filtering to both management and exhibition sidebars.
- Refreshes counts after collection membership changes and during sidebar synchronization.
- Prevents stale asynchronous responses from overwriting newer collection or gallery state.
- Preserves shared collection access during exhibition startup.
- Hides direct counts for restricted exhibition ancestors and limits descendant totals to accessible collections.

**Collection Count Semantics**
- N: files tagged directly to the collection.
- +N: unique files assigned within collapsed sub-collections.
- All Collections: unique files assigned to any collection in the current accessible scope.
- A file assigned directly to a parent and within a descendant can appear in both badges because they represent separate membership scopes.

**Exhibition Pre-Flight Fix**
Previously, Exhibition Mode refused to start unless at least one collection was marked public. This prevented valid deployments containing only private collections shared with specific users.
The pre-flight check now accepts a user collection when it is either:
- Marked public/Exhibition Ready.
- Shared with at least one user.
The startup error and remediation instructions were also updated to describe both supported access paths.

**Implementation Notes**
Counts are derived from collection_files; no schema migration or persisted counter maintenance is required.
Descendant totals use a recursive SQLite query that starts from collections containing countable files and walks upward through their ancestors. This avoids scanning the complete hierarchy closure for empty collections.
Verification
- Verified direct, descendant, and distinct aggregate count behavior.
- Verified hierarchy-aware filtering, searching, expansion, and collapse behavior.
- Verified public, shared, and restricted exhibition collection handling.
- Verified desktop and mobile toolbar layout changes.
- Ran python -m py_compile smartgallery.py.
- Ran Git whitespace and conflict checks.
- Performed correctness and performance review of the recursive count query.

<img width="1257" height="1127" alt="image" src="https://github.com/user-attachments/assets/0562e763-7129-4757-a6c2-05d8f16b9f09" />
